### PR TITLE
Setup wizard & PTI Password check, w/ bonus showDialog refactor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,8 @@
         <activity
             android:name="com.avarsava.stuttersupport.ParentTeacherInterfaceActivity"
             android:screenOrientation="portrait" />
+        <activity android:name="com.avarsava.stuttersupport.SetupActivity"
+            android:screenOrientation="portrait" />
 
         <service
             android:name="com.avarsava.stuttersupport.IntentHandler"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,6 +51,8 @@
             android:screenOrientation="portrait" />
         <activity android:name="com.avarsava.stuttersupport.SetupActivity"
             android:screenOrientation="portrait" />
+        <activity android:name="com.avarsava.stuttersupport.PTIPasswordActivity"
+            android:screenOrientation="portrait" />
 
         <service
             android:name="com.avarsava.stuttersupport.IntentHandler"

--- a/app/src/main/java/com/avarsava/stuttersupport/Dialog.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/Dialog.java
@@ -1,0 +1,71 @@
+package com.avarsava.stuttersupport;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+
+import java.util.concurrent.Callable;
+
+/**
+ * @author  Alexis Varsava <av11sl@brocku.ca>
+ * @version 1.1
+ * @since   1.1
+ *
+ * Helper class for displaying dialogs to the screen.
+ */
+
+public class Dialog {
+
+    /**
+     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
+     * restores the default settings for all activities in the app.
+     *
+     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
+     * @param activity This activity
+     * @param title Title for the dialog
+     * @param message Message to display on dialog
+     */
+    public static void showDialog(Activity activity, String title, CharSequence message) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+
+        if (title != null) builder.setTitle(title);
+
+        builder.setMessage(message);
+        builder.setPositiveButton("OK", null);
+        builder.show();
+    }
+
+    /**
+     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
+     * restores the default settings for all activities in the app.
+     *
+     *
+     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
+     * @param activity This activity
+     * @param title Title for the dialog
+     * @param message Message to display on dialog
+     * @param listenerFunc Method to call on press of OK button.
+     *                     boolean only because it won't accept void
+     */
+    public static void showDialogWithPosListener
+    (Activity activity, String title, CharSequence message, final Callable<Boolean> listenerFunc ) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        DialogInterface.OnClickListener positiveListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                try {
+                    listenerFunc.call();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        if (title != null) builder.setTitle(title);
+
+        builder.setMessage(message);
+        builder.setPositiveButton("OK", positiveListener);
+        builder.setNegativeButton("Cancel", null);
+        builder.show();
+    }
+}

--- a/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends AppCompatActivity {
                 break;
             case R.id.parentTeacherInterfaceButton:
                 intent = new Intent(this,
-                        ParentTeacherInterfaceActivity.class);
+                        PTIPasswordActivity.class);
                 break;
         }
         startActivity(intent);

--- a/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
@@ -15,6 +15,11 @@ import android.view.View;
  */
 public class MainActivity extends AppCompatActivity {
     /**
+     * Helps check if Setup needs to be shown.
+     */
+    private SetupDbHelper dbHelper;
+
+    /**
      * Creates the Activity and displays the splash screen layout.
      *
      * @param savedInstanceState used for internal Android communication.
@@ -23,6 +28,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        dbHelper = new SetupDbHelper(this, "setup.db", "SETUP");
         RegisterAlarmBroadcast();
     }
 
@@ -36,7 +42,11 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = null;
         switch(view.getId()){
             case R.id.splashButton:
-                intent = new Intent(this, MainMenuActivity.class);
+                if(dbHelper.setupIsDone()){
+                    intent = new Intent(this, SetupActivity.class);
+                }else {
+                    intent = new Intent(this, MainMenuActivity.class);
+                }
                 break;
             case R.id.licensesButton:
                 intent = new Intent(this, LicensesActivity.class);

--- a/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Button;
 
 /**
  * @author  Alexis Varsava <av11sl@brocku.ca>
@@ -29,6 +30,12 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         dbHelper = new SetupDbHelper(this, "setup.db", "SETUP");
+        if(!dbHelper.setupIsDone()){
+            View notifPrefs = findViewById(R.id.notificationSettingsButton);
+            View ptInterface = findViewById(R.id.parentTeacherInterfaceButton);
+            notifPrefs.setEnabled(false);
+            ptInterface.setEnabled(false);
+        }
         RegisterAlarmBroadcast();
     }
 
@@ -42,7 +49,7 @@ public class MainActivity extends AppCompatActivity {
         Intent intent = null;
         switch(view.getId()){
             case R.id.splashButton:
-                if(dbHelper.setupIsDone()){
+                if(!dbHelper.setupIsDone()){
                     intent = new Intent(this, SetupActivity.class);
                 }else {
                     intent = new Intent(this, MainMenuActivity.class);

--- a/app/src/main/java/com/avarsava/stuttersupport/MainMenuActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/MainMenuActivity.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * @author  Alexis Varsava <av11sl@brocku.ca>
@@ -173,8 +174,14 @@ public class MainMenuActivity extends FragmentActivity {
             //Show dialog if milestone is hit and social media offer hasn't been made yet
             if((MILESTONES.contains(currentStreak) || isLargeMilestone(currentStreak))
                     && socialMediaAppropriate()) {
-                showDialog(this, getString(R.string.milestone_header),
-                        getString(R.string.milestone_prompt));
+                Dialog.showDialogWithPosListener(this, getString(R.string.milestone_header),
+                        getString(R.string.milestone_prompt),
+                        new Callable<Boolean>() {
+                            @Override
+                            public Boolean call() throws Exception {
+                                return createSocialIntent();
+                            }
+                        });
                 socialMediaOffered = true;
             }
         }
@@ -219,41 +226,15 @@ public class MainMenuActivity extends FragmentActivity {
     }
 
     /**
-     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
-     * creates an intent which the OS uses to post a message to whatever social media app installed
-     * on the device the user chooses.
-     *
-     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
-     * @param activity This activity
-     * @param title Title for the dialog
-     * @param message Message to display on dialog
-     */
-    public void showDialog(Activity activity, String title, CharSequence message) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        DialogInterface.OnClickListener positiveListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                createSocialIntent();
-            }
-        };
-
-        if (title != null) builder.setTitle(title);
-
-        builder.setMessage(message);
-        builder.setPositiveButton(getString(R.string.OK_button), positiveListener);
-        builder.setNegativeButton(getString(R.string.Cancel_button), null);
-        builder.show();
-    }
-
-    /**
      * Creates an implicit Intent which the OS uses to send a message to any social media app
      * that the user may have on their device.
      */
-    private void createSocialIntent() {
+    private boolean createSocialIntent() {
         Intent shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
         shareIntent.putExtra(Intent.EXTRA_TEXT, generateShareMessage());
         startActivity(Intent.createChooser(shareIntent, "Share..."));
+        return true;
     }
 
     /**

--- a/app/src/main/java/com/avarsava/stuttersupport/PTIPasswordActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/PTIPasswordActivity.java
@@ -1,0 +1,70 @@
+package com.avarsava.stuttersupport;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.widget.EditText;
+
+/**
+ * @author  Alexis Varsava <av11sl@brocku.ca>
+ * @version 1.1
+ * @since   1.1
+ *
+ * Prompts for parent's password then launches Parent-Teacher Interface if password is correct.
+ *
+ * TODO: Javadoc
+ * TODO: Reset password???
+ */
+
+public class PTIPasswordActivity extends Activity {
+
+    private final String PASSWORD_KEY = "parent_password";
+
+    SharedPreferences prefs;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState){
+        super.onCreate(savedInstanceState);
+        prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        setContentView(R.layout.activity_pti_password);
+    }
+
+    public void onClick(View view){
+        String expectedPassword, enteredPassword;
+        expectedPassword = prefs.getString(PASSWORD_KEY, "");
+        enteredPassword = ((EditText)findViewById(R.id.passwordInput)).getText().toString();
+
+        if(enteredPassword.equals(expectedPassword)){
+            Intent cont = new Intent(this, ParentTeacherInterfaceActivity.class);
+            startActivity(cont);
+        } else {
+            showDialog(this, "Sorry!", "Your password did not match" +
+                    " the one we have saved. Please try again.");
+        }
+    }
+
+    /**
+     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
+     * restores the default settings for all activities in the app.
+     *
+     * TODO: Abstract to own file, this appears in 3 files now.
+     *
+     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
+     * @param activity This activity
+     * @param title Title for the dialog
+     * @param message Message to display on dialog
+     */
+    public void showDialog(Activity activity, String title, CharSequence message) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+
+        if (title != null) builder.setTitle(title);
+
+        builder.setMessage(message);
+        builder.setPositiveButton(getString(R.string.OK_button), null);
+        builder.show();
+    }
+}

--- a/app/src/main/java/com/avarsava/stuttersupport/PTIPasswordActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/PTIPasswordActivity.java
@@ -42,29 +42,8 @@ public class PTIPasswordActivity extends Activity {
             Intent cont = new Intent(this, ParentTeacherInterfaceActivity.class);
             startActivity(cont);
         } else {
-            showDialog(this, "Sorry!", "Your password did not match" +
+            Dialog.showDialog(this, "Sorry!", "Your password did not match" +
                     " the one we have saved. Please try again.");
         }
-    }
-
-    /**
-     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
-     * restores the default settings for all activities in the app.
-     *
-     * TODO: Abstract to own file, this appears in 3 files now.
-     *
-     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
-     * @param activity This activity
-     * @param title Title for the dialog
-     * @param message Message to display on dialog
-     */
-    public void showDialog(Activity activity, String title, CharSequence message) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-
-        if (title != null) builder.setTitle(title);
-
-        builder.setMessage(message);
-        builder.setPositiveButton(getString(R.string.OK_button), null);
-        builder.show();
     }
 }

--- a/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
@@ -19,7 +19,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Date;
 
-
+//TODO: Javadoc
 public class ParentTeacherInterfaceActivity extends Activity {
     private TrackerDbHelper trackerDbHelper;
 

--- a/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
@@ -34,6 +34,8 @@ public class ParentTeacherInterfaceActivity extends Activity {
     public static Button settingsButton;
     public static Button exportDataButton;
 
+    //TODO: Add password check
+
     @Override
     protected void onCreate(Bundle savedInstanceState){
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/ParentTeacherInterfaceActivity.java
@@ -34,8 +34,6 @@ public class ParentTeacherInterfaceActivity extends Activity {
     public static Button settingsButton;
     public static Button exportDataButton;
 
-    //TODO: Add password check
-
     @Override
     protected void onCreate(Bundle savedInstanceState){
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/avarsava/stuttersupport/SettingsScreenActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SettingsScreenActivity.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 /**
  * @author  Alexis Varsava <av11sl@brocku.ca>
@@ -81,9 +82,15 @@ public class SettingsScreenActivity extends PreferenceActivity{
         restoreButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
-                showDialog(thisActivity,
+                Dialog.showDialogWithPosListener(thisActivity,
                         getString(R.string.restore_defaults),
-                        getString(R.string.restore_defaults_warning));
+                        getString(R.string.restore_defaults_warning),
+                        new Callable<Boolean>() {
+                            @Override
+                            public Boolean call() throws Exception {
+                                return restoreDefaults();
+                            }
+                        });
                 return true;
             }
         });
@@ -120,36 +127,10 @@ public class SettingsScreenActivity extends PreferenceActivity{
     }
 
     /**
-     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
-     * restores the default settings for all activities in the app.
-     *
-     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
-     * @param activity This activity
-     * @param title Title for the dialog
-     * @param message Message to display on dialog
-     */
-    public void showDialog(Activity activity, String title, CharSequence message) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        DialogInterface.OnClickListener positiveListener = new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                restoreDefaults();
-            }
-        };
-
-        if (title != null) builder.setTitle(title);
-
-        builder.setMessage(message);
-        builder.setPositiveButton(getString(R.string.OK_button), positiveListener);
-        builder.setNegativeButton(getString(R.string.Cancel_button), null);
-        builder.show();
-    }
-
-    /**
      * Restores the default settings for all activities, then refreshes the settings screen
      * to reflect the changes.
      */
-    private void restoreDefaults(){
+    private boolean restoreDefaults(){
         SharedPreferences preferences =
                 PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         SharedPreferences.Editor editor = preferences.edit();
@@ -158,5 +139,7 @@ public class SettingsScreenActivity extends PreferenceActivity{
 
         setPreferenceScreen(null);
         addPreferencesFromResource(prefsFile);
+
+        return true;
     }
 }

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -1,0 +1,62 @@
+package com.avarsava.stuttersupport;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+
+/**
+ * @author Alexis Varsava <av11sl@brocku.ca>
+ * @version 1.1
+ * @since   1.1
+ *
+ * First time the app is launched, user is sent to this screen
+ * to fill out a form with starting preferences.
+ */
+
+public class SetupActivity extends PreferenceActivity {
+    /**
+     * Resource ID of settings file to expand into layout.
+     */
+    protected int prefsFile = 0;
+
+    /**
+     * Creates a settings screen based on the preferences file carried in the Extras. Uses
+     * an automatic function of Android to generate the settings screen.
+     *
+     * @param savedInstanceState Bundle containing the extras, including the preferences file.
+     */
+    @Override
+    public void onCreate(Bundle savedInstanceState){
+        super.onCreate(savedInstanceState);
+
+        prefsFile = R.xml.setup_prefs;
+
+        // Load the preferences from an XML resource
+        addPreferencesFromResource(prefsFile);
+
+        //TODO: show dialog
+    }
+
+    /**
+     * Expands preferences from XML into a settings screen layout, then sets back and restore
+     * buttons to listen for click activity.
+     *
+     * @param preferencesResId Resoure ID of the preferences file to expand
+     */
+    @Override
+    public void addPreferencesFromResource(int preferencesResId){
+        super.addPreferencesFromResource(preferencesResId);
+
+        final Activity thisActivity = this;
+        //TODO: Convert to submit button
+        Preference backButton = findPreference("backButton");
+        backButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                finish();
+                return true;
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -43,8 +43,9 @@ public class SetupActivity extends PreferenceActivity {
         // Load the preferences from an XML resource
         addPreferencesFromResource(prefsFile);
 
-        showDialog(this, "Welcome!", "Please set your initial settings before beginning" +
-                " to use this app.");
+        //TODO: Make strings not hardcoded
+        showDialog(this, "Welcome!", "Please set your initial settings before" +
+                " beginning to use this app.");
     }
 
     /**

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -71,7 +71,7 @@ public class SetupActivity extends PreferenceActivity {
 
         final Activity thisActivity = this;
         Preference submitButton = findPreference("submitButton");
-        
+
         submitButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -42,7 +42,7 @@ public class SetupActivity extends PreferenceActivity {
 
         // Load the preferences from an XML resource
         addPreferencesFromResource(prefsFile);
-        
+
         showDialog(this, "Welcome!", "Please set your initial settings before beginning" +
                 " to use this app.");
     }
@@ -62,6 +62,8 @@ public class SetupActivity extends PreferenceActivity {
 
         final Activity thisActivity = this;
         Preference submitButton = findPreference("submitButton");
+
+        //TODO: check for blank entries and reject submission
         submitButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -52,7 +52,7 @@ public class SetupActivity extends PreferenceActivity {
         addPreferencesFromResource(prefsFile);
 
         //TODO: Make strings not hardcoded
-        showDialog(this, "Welcome!", "Please set your initial settings before" +
+        Dialog.showDialog(this, "Welcome!", "Please set your initial settings before" +
                 " beginning to use this app.");
     }
 
@@ -81,7 +81,7 @@ public class SetupActivity extends PreferenceActivity {
                     return true;
                 } else {
                     //TODO: Make strings not hardcoded
-                    showDialog(thisActivity, "Sorry!", "Please fill out every" +
+                    Dialog.showDialog(thisActivity, "Sorry!", "Please fill out every" +
                             " setting before pressing Submit.");
                     return false;
                 }
@@ -109,24 +109,5 @@ public class SetupActivity extends PreferenceActivity {
         }
 
         return true;
-    }
-
-    /**
-     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
-     * restores the default settings for all activities in the app.
-     *
-     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
-     * @param activity This activity
-     * @param title Title for the dialog
-     * @param message Message to display on dialog
-     */
-    public void showDialog(Activity activity, String title, CharSequence message) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-
-        if (title != null) builder.setTitle(title);
-
-        builder.setMessage(message);
-        builder.setPositiveButton(getString(R.string.OK_button), null);
-        builder.show();
     }
 }

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -1,6 +1,8 @@
 package com.avarsava.stuttersupport;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
@@ -21,6 +23,11 @@ public class SetupActivity extends PreferenceActivity {
     protected int prefsFile = 0;
 
     /**
+     * Database helper for tracking Setup completedness
+     */
+    private SetupDbHelper dbHelper;
+
+    /**
      * Creates a settings screen based on the preferences file carried in the Extras. Uses
      * an automatic function of Android to generate the settings screen.
      *
@@ -28,19 +35,24 @@ public class SetupActivity extends PreferenceActivity {
      */
     @Override
     public void onCreate(Bundle savedInstanceState){
+        dbHelper = new SetupDbHelper(this, "setup.db", "SETUP");
         super.onCreate(savedInstanceState);
 
         prefsFile = R.xml.setup_prefs;
 
         // Load the preferences from an XML resource
         addPreferencesFromResource(prefsFile);
-
-        //TODO: show dialog
+        
+        showDialog(this, "Welcome!", "Please set your initial settings before beginning" +
+                " to use this app.");
     }
 
     /**
      * Expands preferences from XML into a settings screen layout, then sets back and restore
      * buttons to listen for click activity.
+     *
+     * Since all the settings are just SharedPreferences, don't need to worry about actually
+     * 'submitting' anything.
      *
      * @param preferencesResId Resoure ID of the preferences file to expand
      */
@@ -49,14 +61,33 @@ public class SetupActivity extends PreferenceActivity {
         super.addPreferencesFromResource(preferencesResId);
 
         final Activity thisActivity = this;
-        //TODO: Convert to submit button
-        Preference backButton = findPreference("backButton");
-        backButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        Preference submitButton = findPreference("submitButton");
+        submitButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
+                dbHelper.setDone();
                 finish();
                 return true;
             }
         });
+    }
+
+    /**
+     * Shows a dialog with a message, and 'OK' and 'Cancel' buttons. If the user presses 'OK',
+     * restores the default settings for all activities in the app.
+     *
+     * based on https://stackoverflow.com/questions/8227820/alert-dialog-two-buttons
+     * @param activity This activity
+     * @param title Title for the dialog
+     * @param message Message to display on dialog
+     */
+    public void showDialog(Activity activity, String title, CharSequence message) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+
+        if (title != null) builder.setTitle(title);
+
+        builder.setMessage(message);
+        builder.setPositiveButton(getString(R.string.OK_button), null);
+        builder.show();
     }
 }

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupActivity.java
@@ -2,10 +2,13 @@ package com.avarsava.stuttersupport;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceManager;
+
+import java.util.Map;
 
 /**
  * @author Alexis Varsava <av11sl@brocku.ca>
@@ -17,6 +20,11 @@ import android.preference.PreferenceActivity;
  */
 
 public class SetupActivity extends PreferenceActivity {
+    /**
+     * Number of settings present in XML
+     */
+    private final int NUM_OF_SETTINGS = 12;
+
     /**
      * Resource ID of settings file to expand into layout.
      */
@@ -63,16 +71,44 @@ public class SetupActivity extends PreferenceActivity {
 
         final Activity thisActivity = this;
         Preference submitButton = findPreference("submitButton");
-
-        //TODO: check for blank entries and reject submission
+        
         submitButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
-                dbHelper.setDone();
-                finish();
-                return true;
+                if(allPrefsSet()) {
+                    dbHelper.setDone();
+                    finish();
+                    return true;
+                } else {
+                    //TODO: Make strings not hardcoded
+                    showDialog(thisActivity, "Sorry!", "Please fill out every" +
+                            " setting before pressing Submit.");
+                    return false;
+                }
+
             }
         });
+    }
+
+    /**
+     * Determines whether all preferences in Setup have a value if applicable.
+     *
+     * @return true if all preferences have been set appropriately.
+     */
+    private boolean allPrefsSet(){
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+        Map<String, ?> allprefs = preferences.getAll();
+
+        if(allprefs.size() != NUM_OF_SETTINGS) return false;
+
+        for(Map.Entry<String, ?> entry : allprefs.entrySet()){
+            String prefValue = entry.getValue().toString();
+            if (prefValue == null){
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
@@ -20,7 +20,7 @@ public class SetupDbHelper extends DatabaseHelper {
     public static final String C_NAME = "name";
     public static final String C_VALUE = "value";
     public static final String R_DONE = "done";
-    public static final int TRUE = 0;
+    public static final int TRUE = 1;
     public static final int FALSE = 0;
 
     /**

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
@@ -2,6 +2,7 @@ package com.avarsava.stuttersupport;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
@@ -60,5 +61,20 @@ public class SetupDbHelper extends DatabaseHelper {
         SQLiteDatabase db = getWritableDatabase();
         db.update(TABLE, existingRow, C_NAME+"=?", new String[]{R_DONE});
         db.close();
+    }
+
+    public boolean setupIsDone(){
+        int value;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.query(TABLE,
+                new String[]{C_VALUE},
+                C_NAME+"=?",
+                new String[]{R_DONE},
+                null, null, null);
+        cursor.moveToFirst();
+        value = cursor.getInt(0);
+        db.close();
+
+        return value == 1;
     }
 }

--- a/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
+++ b/app/src/main/java/com/avarsava/stuttersupport/SetupDbHelper.java
@@ -1,0 +1,64 @@
+package com.avarsava.stuttersupport;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
+
+/**
+ * @author Alexis Varsava <av11sl@brocku.ca>
+ * @version 1.1
+ * @since   1.1
+ *
+ * Keeps track of whether the Setup Wizard has run or not.
+ * Unfortunately this is more permanent than a preference.
+ */
+
+public class SetupDbHelper extends DatabaseHelper {
+    public static final String C_NAME = "name";
+    public static final String C_VALUE = "value";
+    public static final String R_DONE = "done";
+    public static final int TRUE = 0;
+    public static final int FALSE = 0;
+
+    /**
+     * Database helper constructor. Saves information to object and creates SQLite helper.
+     *
+     * @param context Application context
+     * @param dbname  name of the database to open
+     * @param table   name of the table to open from said database
+     */
+    public SetupDbHelper(Context context, String dbname, String table) {
+        super(context, dbname, table);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        String sql = "CREATE TABLE " + TABLE + " (" + C_NAME + " TEXT PRIMARY KEY, "
+                + C_VALUE + " INTEGER NOT NULL)";
+        db.execSQL(sql);
+
+        ContentValues newRow = new ContentValues();
+        newRow.clear();
+        newRow.put(C_NAME, R_DONE);
+        newRow.put(C_VALUE, FALSE);
+        try{
+            db.insertOrThrow(TABLE, null, newRow);
+        } catch (SQLException e){
+            Log.e("DATABASE", "ERROR when adding to SetupDB");
+            e.printStackTrace();
+        }
+    }
+
+    public void setDone(){
+        ContentValues existingRow = new ContentValues();
+        existingRow.clear();
+        existingRow.put(C_NAME, R_DONE);
+        existingRow.put(C_VALUE, TRUE);
+
+        SQLiteDatabase db = getWritableDatabase();
+        db.update(TABLE, existingRow, C_NAME+"=?", new String[]{R_DONE});
+        db.close();
+    }
+}

--- a/app/src/main/res/layout/activity_pti_password.xml
+++ b/app/src/main/res/layout/activity_pti_password.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/PasswordTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:ems="10"
+        android:inputType="text"
+        android:text="Please enter your password."
+        android:textAlignment="center"
+        app:layout_constraintBottom_toTopOf="@+id/passwordInput"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Please enter your password." />
+
+    <EditText
+        android:id="@+id/passwordInput"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:ems="10"
+        android:hint="Enter password here..."
+        android:inputType="textPassword"
+        app:layout_constraintBottom_toTopOf="@+id/passwordSubmit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/PasswordTitle" />
+
+    <Button
+        android:id="@+id/passwordSubmit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="24dp"
+        android:onClick="onClick"
+        android:text="Submit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/passwordInput"
+        tools:text="Submit" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+
+<PreferenceCategory android:title="Global Settings">
+<EditTextPreference
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:inputType="number"
+    android:key="pti_userAge"
+    android:maxLength="3"
+    android:numeric="integer"
+    android:title="User Age" />
+<SwitchPreference
+    android:defaultValue="true"
+    android:key="pti_socialMediaIntegration"
+    android:title="Social Media Integration" />
+</PreferenceCategory>
+
+<SwitchPreference
+    android:defaultValue="false"
+    android:key="pti_disableNotifications"
+    android:title="Disable Notifications" />
+<PreferenceCategory android:title="Game Settings">
+
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="pti_tg_override"
+        android:title="Override Train Game Difficulty" />
+    <EditTextPreference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="1"
+        android:inputType="number"
+        android:key="pti_tg_difficulty"
+        android:maxLength="1"
+        android:numeric="integer"
+        android:title="Train Game Difficulty" />
+    <SwitchPreference
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:defaultValue="false"
+        android:key="pti_override_deepBreathing"
+        android:title="Override Deep Breathing Settings" />
+    <EditTextPreference
+        android:defaultValue="7"
+        android:inputType="number"
+        android:key="pti_db_inhaleLength"
+        android:maxLength="2"
+        android:numeric="integer"
+        android:title="Inhale Length" />
+    <EditTextPreference android:title="Exhale Length"
+        android:key="pti_db_exhaleLength"
+        android:defaultValue="11"
+        android:inputType="number"
+        android:numeric="integer"
+        android:maxLength="2"/>
+    <EditTextPreference android:title="Number of Breaths"
+        android:key="pti_db_noOfBreaths"
+        android:defaultValue="3"
+        android:inputType="number"
+        android:numeric="integer"
+        android:maxLength="2"/>
+
+
+</PreferenceCategory>
+<PreferenceCategory android:title="Menu">
+    <Preference android:title="Restore Defaults"
+        android:key="restoreDefaults" />
+    <Preference android:title="Back to Menu"
+        android:key="backButton" />
+</PreferenceCategory>
+</PreferenceScreen>

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -3,6 +3,10 @@
 
     <PreferenceCategory android:title="Global Settings">
         <EditTextPreference
+            android:key="parent_password"
+            android:password="true"
+            android:title="Parent/Teacher Interface password"/>
+        <EditTextPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:inputType="number"
@@ -14,8 +18,6 @@
             android:defaultValue="true"
             android:key="pti_socialMediaIntegration"
             android:title="Social Media Integration" />
-
-
         <SwitchPreference
             android:defaultValue="false"
             android:key="pti_disableNotifications"

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -36,8 +36,7 @@
             android:entries="@array/difficultyLevels"
             android:entryValues="@array/levelValues"
             android:key="tg_Difficulty"
-            android:title="Train Game Difficulty"
-            android:dependency="pti_tg_override"/>
+            android:title="Train Game Difficulty" />
 
         <SwitchPreference
             android:layout_width="wrap_content"
@@ -52,22 +51,19 @@
             android:key="db_inhaleLength"
             android:maxLength="2"
             android:numeric="integer"
-            android:title="Inhale Length"
-            android:dependency="pti_override_deepBreathing"/>
+            android:title="Inhale Length"/>
         <EditTextPreference android:title="Exhale Length"
             android:key="db_exhaleLength"
             android:defaultValue="11"
             android:inputType="number"
             android:numeric="integer"
-            android:maxLength="2"
-            android:dependency="pti_override_deepBreathing"/>
+            android:maxLength="2"/>
         <EditTextPreference android:title="Number of Breaths"
             android:key="db_noOfBreaths"
             android:defaultValue="3"
             android:inputType="number"
             android:numeric="integer"
-            android:maxLength="2"
-            android:dependency="pti_override_deepBreathing"/>
+            android:maxLength="2"/>
 
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -1,72 +1,76 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-<PreferenceCategory android:title="Global Settings">
-<EditTextPreference
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:inputType="number"
-    android:key="pti_userAge"
-    android:maxLength="3"
-    android:numeric="integer"
-    android:title="User Age" />
-<SwitchPreference
-    android:defaultValue="true"
-    android:key="pti_socialMediaIntegration"
-    android:title="Social Media Integration" />
-</PreferenceCategory>
-
-<SwitchPreference
-    android:defaultValue="false"
-    android:key="pti_disableNotifications"
-    android:title="Disable Notifications" />
-<PreferenceCategory android:title="Game Settings">
-
-    <SwitchPreference
-        android:defaultValue="false"
-        android:key="pti_tg_override"
-        android:title="Override Train Game Difficulty" />
-    <EditTextPreference
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:defaultValue="1"
-        android:inputType="number"
-        android:key="pti_tg_difficulty"
-        android:maxLength="1"
-        android:numeric="integer"
-        android:title="Train Game Difficulty" />
-    <SwitchPreference
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:defaultValue="false"
-        android:key="pti_override_deepBreathing"
-        android:title="Override Deep Breathing Settings" />
-    <EditTextPreference
-        android:defaultValue="7"
-        android:inputType="number"
-        android:key="pti_db_inhaleLength"
-        android:maxLength="2"
-        android:numeric="integer"
-        android:title="Inhale Length" />
-    <EditTextPreference android:title="Exhale Length"
-        android:key="pti_db_exhaleLength"
-        android:defaultValue="11"
-        android:inputType="number"
-        android:numeric="integer"
-        android:maxLength="2"/>
-    <EditTextPreference android:title="Number of Breaths"
-        android:key="pti_db_noOfBreaths"
-        android:defaultValue="3"
-        android:inputType="number"
-        android:numeric="integer"
-        android:maxLength="2"/>
+    <PreferenceCategory android:title="Global Settings">
+        <EditTextPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:key="pti_userAge"
+            android:maxLength="3"
+            android:numeric="integer"
+            android:title="User Age" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="pti_socialMediaIntegration"
+            android:title="Social Media Integration" />
 
 
-</PreferenceCategory>
-<PreferenceCategory android:title="Menu">
-    <Preference android:title="Restore Defaults"
-        android:key="restoreDefaults" />
-    <Preference android:title="Back to Menu"
-        android:key="backButton" />
-</PreferenceCategory>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="pti_disableNotifications"
+            android:title="Disable Notifications" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="Game Settings">
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="pti_tg_override"
+            android:title="Override Train Game Difficulty"
+            android:disableDependentsState="false"/>
+        <ListPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/difficultyLevels"
+            android:entryValues="@array/levelValues"
+            android:key="tg_Difficulty"
+            android:title="Train Game Difficulty"
+            android:dependency="pti_tg_override"/>
+
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="false"
+            android:key="pti_override_deepBreathing"
+            android:title="Override Deep Breathing Settings"
+            android:disableDependentsState="false"/>
+        <EditTextPreference
+            android:defaultValue="7"
+            android:inputType="number"
+            android:key="db_inhaleLength"
+            android:maxLength="2"
+            android:numeric="integer"
+            android:title="Inhale Length"
+            android:dependency="pti_override_deepBreathing"/>
+        <EditTextPreference android:title="Exhale Length"
+            android:key="db_exhaleLength"
+            android:defaultValue="11"
+            android:inputType="number"
+            android:numeric="integer"
+            android:maxLength="2"
+            android:dependency="pti_override_deepBreathing"/>
+        <EditTextPreference android:title="Number of Breaths"
+            android:key="db_noOfBreaths"
+            android:defaultValue="3"
+            android:inputType="number"
+            android:numeric="integer"
+            android:maxLength="2"
+            android:dependency="pti_override_deepBreathing"/>
+
+
+    </PreferenceCategory>
+    <PreferenceCategory android:title="Menu">
+        <Preference android:title="Submit"
+            android:key="submitButton" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -22,7 +22,23 @@
             android:defaultValue="false"
             android:key="pti_disableNotifications"
             android:title="Disable Notifications" />
+        <!-- Hour in 24h time for alarm to fire -->
+        <EditTextPreference android:title="Notification Hour"
+            android:key="notificationCustomHour"
+            android:defaultValue="16"
+            android:inputType="number"
+            android:numeric="integer"
+            android:maxLength="2" />
+
+        <!-- Minute at hour for alarm to fire -->
+        <EditTextPreference android:title="Notification Minute"
+            android:key="notificationCustomMinute"
+            android:defaultValue="00"
+            android:inputType="number"
+            android:numeric="integer"
+            android:maxLength="2" />
     </PreferenceCategory>
+
     <PreferenceCategory android:title="Game Settings">
 
         <SwitchPreference

--- a/app/src/main/res/xml/setup_prefs.xml
+++ b/app/src/main/res/xml/setup_prefs.xml
@@ -9,11 +9,12 @@
         <EditTextPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:defaultValue="13"
             android:inputType="number"
             android:key="pti_userAge"
             android:maxLength="3"
             android:numeric="integer"
-            android:title="User Age" />
+            android:title="Child's Age" />
         <SwitchPreference
             android:defaultValue="true"
             android:key="pti_socialMediaIntegration"
@@ -51,6 +52,7 @@
             android:layout_height="wrap_content"
             android:entries="@array/difficultyLevels"
             android:entryValues="@array/levelValues"
+            android:defaultValue="1"
             android:key="tg_Difficulty"
             android:title="Train Game Difficulty" />
 


### PR DESCRIPTION
1. Adds the First-Time Setup to the app. Checks a database for a 0 or a 1, if the value is 0, shows the first-time setup and does not let you progress until you've set all the options. 

2. Adds the PTI password activity between MainActivity and the PTI Activity. Does a simple string compare because AFAIK there's no way to dump the preferences from the phone. 

3. By this point, showDialog() has been implemented in approx. 4 different files. Refactored this to a new file. For the dialogs requiring an action when OK is pressed, that can be passed in as a Callable<Boolean> with showDialogWithPosListener().

Issues:
- Do we want a password reset functionality, and if so, how to handle authenticating it?
- Password prompt is not very pretty.